### PR TITLE
A quick-and-dirty support for async call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,11 @@ license = "MIT/Apache-2.0"
 name = "slack-hooked"
 readme = "README.md"
 repository = "https://github.com/ch3ck/rusty-slack"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 
+[features]
+async = []
 
 [dependencies]
 chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -21,11 +21,18 @@ Requires rust 1.61 or newer.
 
 # Usage
 
-Add this to your `Cargo.toml`:
+Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-slack-hooked = "0.9"
+slack-hooked = "0.10"
+```
+
+or for use with Tokio or Actix:
+
+```toml
+[dependencies]
+slack-hooked = { version = "0.10", features = ["async"] }
 ```
 
 Add the crate to your existing project:

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -30,7 +30,12 @@ impl Slack {
 impl Slack {
     /// Send payload to slack service
     pub async fn send(&self, payload: &Payload) -> Result<()> {
-        let response = &self.client.post(self.hook.clone()).json(payload).send().await?;
+        let response = &self
+            .client
+            .post(self.hook.clone())
+            .json(payload)
+            .send()
+            .await?;
 
         if response.status().is_success() {
             Ok(())


### PR DESCRIPTION
A quick-and-dirty support for async call required by reqwest when executed in Tokio or Actix